### PR TITLE
#37 - 게시글 및 게시글 댓글 서비스 로직의 테스트와 골격 잡기

### DIFF
--- a/training-board/src/main/java/com/study/trainingboard/domain/article/controller/view/MainController.java
+++ b/training-board/src/main/java/com/study/trainingboard/domain/article/controller/view/MainController.java
@@ -1,0 +1,13 @@
+package com.study.trainingboard.domain.article.controller.view;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+
+    @GetMapping("/")
+    public String root() {
+        return "redirect:/articles";
+    }
+}

--- a/training-board/src/main/java/com/study/trainingboard/domain/article/dto/ArticleCommentDto.java
+++ b/training-board/src/main/java/com/study/trainingboard/domain/article/dto/ArticleCommentDto.java
@@ -1,0 +1,48 @@
+package com.study.trainingboard.domain.article.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ArticleCommentDto {
+
+    private final String content;
+
+    private final LocalDateTime createdAt;
+
+    private final String createdBy;
+
+    private final LocalDateTime updatedAt;
+
+    private final String updatedBy;
+
+    private ArticleCommentDto(
+            String content,
+            LocalDateTime createdAt,
+            String createdBy,
+            LocalDateTime updatedAt,
+            String updatedBy
+    ) {
+        this.content = content;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+        this.updatedAt = updatedAt;
+        this.updatedBy = updatedBy;
+    }
+
+    public static ArticleCommentDto of(
+            String content,
+            LocalDateTime createdAt,
+            String createdBy,
+            LocalDateTime updatedAt,
+            String updatedBy
+    ) {
+        return new ArticleCommentDto(
+                content,
+                createdAt,
+                createdBy,
+                updatedAt,
+                updatedBy);
+    }
+}

--- a/training-board/src/main/java/com/study/trainingboard/domain/article/dto/ArticleDto.java
+++ b/training-board/src/main/java/com/study/trainingboard/domain/article/dto/ArticleDto.java
@@ -1,0 +1,61 @@
+package com.study.trainingboard.domain.article.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ArticleDto {
+
+    private final String title;
+
+    private final String content;
+
+    private final String hashtag;
+
+    private final LocalDateTime createdAt;
+
+    private final String createdBy;
+
+    private final LocalDateTime updatedAt;
+
+    private final String updatedBy;
+
+    private ArticleDto(
+            String title,
+            String content,
+            String hashtag,
+            LocalDateTime createdAt,
+            String createdBy,
+            LocalDateTime updatedAt,
+            String updatedBy
+    ) {
+        this.title = title;
+        this.content = content;
+        this.hashtag = hashtag;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+        this.updatedAt = updatedAt;
+        this.updatedBy = updatedBy;
+    }
+
+    public static ArticleDto of(
+            String title,
+            String content,
+            String hashtag,
+            LocalDateTime createdAt,
+            String createdBy,
+            LocalDateTime updatedAt,
+            String updatedBy
+    ) {
+        return new ArticleDto(
+                title,
+                content,
+                hashtag,
+                createdAt,
+                createdBy,
+                updatedAt,
+                updatedBy
+        );
+    }
+}

--- a/training-board/src/main/java/com/study/trainingboard/domain/article/dto/ArticleUpdateDto.java
+++ b/training-board/src/main/java/com/study/trainingboard/domain/article/dto/ArticleUpdateDto.java
@@ -1,0 +1,35 @@
+package com.study.trainingboard.domain.article.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ArticleUpdateDto {
+
+    private final String title;
+
+    private final String content;
+
+    private final String hashtag;
+
+    private ArticleUpdateDto(
+            String title,
+            String content,
+            String hashtag
+    ) {
+        this.title = title;
+        this.content = content;
+        this.hashtag = hashtag;
+    }
+
+    public static ArticleUpdateDto of(
+            String title,
+            String content,
+            String hashtag
+    ) {
+        return new ArticleUpdateDto(
+                title,
+                content,
+                hashtag
+        );
+    }
+}

--- a/training-board/src/main/java/com/study/trainingboard/domain/article/model/constant/SearchType.java
+++ b/training-board/src/main/java/com/study/trainingboard/domain/article/model/constant/SearchType.java
@@ -1,0 +1,9 @@
+package com.study.trainingboard.domain.article.model.constant;
+
+public enum SearchType {
+    TITLE,
+    CONTENT,
+    ID,
+    NICKNAME,
+    HASHTAG
+}

--- a/training-board/src/main/java/com/study/trainingboard/domain/article/service/ArticleCommentService.java
+++ b/training-board/src/main/java/com/study/trainingboard/domain/article/service/ArticleCommentService.java
@@ -1,0 +1,22 @@
+package com.study.trainingboard.domain.article.service;
+
+import com.study.trainingboard.domain.article.dto.ArticleCommentDto;
+import com.study.trainingboard.domain.article.repository.ArticleCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleCommentService {
+
+    private final ArticleCommentRepository articleCommentRepository;
+
+    @Transactional(readOnly = true)
+    public List<ArticleCommentDto> searchArticleComment(Long articleId) {
+        return List.of();
+    }
+}

--- a/training-board/src/main/java/com/study/trainingboard/domain/article/service/ArticleService.java
+++ b/training-board/src/main/java/com/study/trainingboard/domain/article/service/ArticleService.java
@@ -1,0 +1,45 @@
+package com.study.trainingboard.domain.article.service;
+
+import com.study.trainingboard.domain.article.dto.ArticleDto;
+import com.study.trainingboard.domain.article.dto.ArticleUpdateDto;
+import com.study.trainingboard.domain.article.model.constant.SearchType;
+import com.study.trainingboard.domain.article.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticles(
+            SearchType title,
+            String searchKeyword
+    ) {
+        return Page.empty();
+    }
+
+    @Transactional(readOnly = true)
+    public ArticleDto searchArticle(Long articleId) {
+        return null;
+    }
+
+    public void saveArticle(ArticleDto dto) {
+
+    }
+
+    public void updateArticle(
+            Long articleId,
+            ArticleUpdateDto dto
+    ) {
+
+    }
+
+    public void deleteArticle(Long articleId) {
+    }
+}

--- a/training-board/src/test/java/com/study/trainingboard/domain/article/controller/view/MainControllerTest.java
+++ b/training-board/src/test/java/com/study/trainingboard/domain/article/controller/view/MainControllerTest.java
@@ -1,0 +1,34 @@
+package com.study.trainingboard.domain.article.controller.view;
+
+import com.study.trainingboard.global.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(SecurityConfig.class)
+@WebMvcTest(MainController.class)
+class MainControllerTest {
+
+    private final MockMvc mockMvc;
+
+    public MainControllerTest(@Autowired MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @Test
+    @DisplayName("홈 페이지 테스트")
+    void 홈_페이지_테스트() throws Exception {
+        // Given
+
+        // When & Then
+        mockMvc.perform(get("/"))
+                .andExpect(status().is3xxRedirection());
+    }
+
+}

--- a/training-board/src/test/java/com/study/trainingboard/domain/article/service/ArticleCommentServiceTest.java
+++ b/training-board/src/test/java/com/study/trainingboard/domain/article/service/ArticleCommentServiceTest.java
@@ -1,0 +1,67 @@
+package com.study.trainingboard.domain.article.service;
+
+import com.study.trainingboard.domain.article.dto.ArticleCommentDto;
+import com.study.trainingboard.domain.article.model.entity.Article;
+import com.study.trainingboard.domain.article.model.entity.ArticleComment;
+import com.study.trainingboard.domain.article.repository.ArticleCommentRepository;
+import com.study.trainingboard.domain.article.repository.ArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+
+@DisplayName("비즈니스 로직 - 게시글 댓글")
+@ExtendWith(MockitoExtension.class)
+class ArticleCommentServiceTest {
+
+    @InjectMocks
+    private ArticleCommentService sut;
+
+    @Mock
+    private ArticleCommentRepository articleCommentRepository;
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @Test
+    @DisplayName("게시글 ID를 주면, 해당 게시글의 댓글 리스트를 반환한다.")
+    void 게시글댓글_조회_테스트() throws Exception {
+        // Given
+        Long articleId = 1L;
+        Article savedArticle = Article.of(
+                "test title",
+                "test content",
+                "test"
+        );
+
+        given(articleRepository.findById(articleId))
+                .willReturn(Optional.of(savedArticle));
+        
+        // When
+        List<ArticleCommentDto> articleComments = sut.searchArticleComment(articleId);
+        
+        // Then
+        assertThat(articleComments).isNotNull();
+        then(articleRepository).should().findById(articleId);
+    }
+    
+    @Test
+    @DisplayName("댓글 정보를 입력하면, 댓글을 저장한다.")
+    void 게시글댓글_생성_테스트() throws Exception {
+        // Given
+        
+        // When
+        
+        // Then
+    }
+
+}

--- a/training-board/src/test/java/com/study/trainingboard/domain/article/service/ArticleServiceTest.java
+++ b/training-board/src/test/java/com/study/trainingboard/domain/article/service/ArticleServiceTest.java
@@ -1,0 +1,117 @@
+package com.study.trainingboard.domain.article.service;
+
+import com.study.trainingboard.domain.article.dto.ArticleDto;
+import com.study.trainingboard.domain.article.dto.ArticleUpdateDto;
+import com.study.trainingboard.domain.article.model.constant.SearchType;
+import com.study.trainingboard.domain.article.model.entity.Article;
+import com.study.trainingboard.domain.article.repository.ArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 게시글")
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+
+    @InjectMocks
+    private ArticleService sut;
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @Test
+    @DisplayName("게시글을 검색하면, 게시글 리스트를 반환한다.")
+    void 게시글_검색_테스트() throws Exception {
+        // Given
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticles(
+                SearchType.TITLE,
+                "search keyword"
+        );
+
+        // Then
+        assertThat(articles).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
+    void 게시글_조회_테스트() throws Exception {
+        // Given
+        Long articleId = 1L;
+
+        // When
+        ArticleDto article = sut.searchArticle(articleId);
+
+        // Then
+        assertThat(article).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시글 정보를 입력하면, 게시글을 생성한다.")
+    void 게시글_생성_테스트() throws Exception {
+        // Given
+        ArticleDto dto = ArticleDto.of(
+                "Test title",
+                "Test content",
+                "test hashtag",
+                LocalDateTime.now(),
+                "pepe",
+                LocalDateTime.now(),
+                "pepe"
+        );
+        given(articleRepository.save(any(Article.class)))
+                .willReturn(null);
+
+        // When
+        sut.saveArticle(dto);
+
+        // Then
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @Test
+    @DisplayName("게시글 id와 수정 정보를 입력하면, 게시글을 수정한다.")
+    void 게시글_수정_테스트() throws Exception {
+        // Given
+        Long articleId = 1L;
+        ArticleUpdateDto dto = ArticleUpdateDto.of(
+                "Test title",
+                "Test content",
+                "test hashtag"
+        );
+        given(articleRepository.save(any(Article.class)))
+                .willReturn(null);
+
+        // When
+        sut.updateArticle(articleId, dto);
+
+        // Then
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @Test
+    @DisplayName("게시글의 ID를 입력하면, 게시글을 삭제한다.")
+    void 게시글_삭제_테스트() throws Exception {
+        // Given
+        Long articleId = 1L;
+        willDoNothing().given(articleRepository).delete(any(Article.class));
+
+        // When
+        sut.deleteArticle(articleId);
+
+        // Then
+        then(articleRepository).should().delete(any(Article.class));
+    }
+
+
+}


### PR DESCRIPTION
다음의 기능을 테스트로 표현

* 게시글 검색하면 게시글 리스트 반환
* 게시글을 ID로 조회
* 게시글 생성
* 게시글 수정
* 게시글 삭제

필요한 dto 와 enum을 함께 작성했는데,
추후에 수정할 수도 있음